### PR TITLE
feat: redefine beam_func and sky_func to take keyword-only inputs for flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ If you use limTOD in your research, please cite:
 - **ant_latitude_deg** (`float`): Latitude of the antenna/site in degrees.
 - **ant_longitude_deg** (`float`): Longitude of the antenna/site in degrees.
 - **ant_height_m** (`float`): Height of the antenna/site in meters.
-- **beam_func** (`function`): Function that takes frequency and nside as input and returns the beam map.
-- **sky_func** (`function`): Function that takes frequency and nside as input and returns the sky map.
+- **beam_func** (`function`): Function that takes _keyword-only_ inputs, two of which must be `freq` (for frequency) and `nside` and returns the HEALPix beam map of shape (npix,). Optional keywords can be passed to the function for customisation.
+- **sky_func** (`function`): Function that takes _keyword-only_ inputs, two of which must be `freq` (for frequency) and `nside` and returns the HEALPix sky map of shape (npix,). Optional keywords can be passed to the function for customisation.
 - **nside** (`int`, optional): The nside parameter for Healpix maps.
 
 #### Observation Parameters:
@@ -230,8 +230,8 @@ class limTODsim:
 - `ant_latitude_deg` (float): Antenna latitude in degrees
 - `ant_longitude_deg` (float): Antenna longitude in degrees  
 - `ant_height_m` (float): Antenna height above sea level in meters
-- `beam_func` (callable): Function returning beam map given (freq, nside)
-- `sky_func` (callable): Function returning sky map given (freq, nside)
+- `beam_func` (callable): Function returning beam map given (freq, nside) as keyword arguments
+- `sky_func` (callable): Function returning sky map given (freq, nside) as keyword arguments
 - `nside` (int): HEALPix resolution parameter (must be power of 2)
 
 ### Core Functions
@@ -444,7 +444,7 @@ This implements the discrete version of the beam convolution integral that produ
 Generate elliptical Gaussian beam pattern.
 
 ```python
-def example_beam_map(freq, nside, FWHM_major=1.1, FWHM_minor=1.1)
+def example_beam_map(*, freq, nside, FWHM_major=1.1, FWHM_minor=1.1)
 ```
 
 ##### `GDSM_sky_model()`
@@ -452,7 +452,7 @@ def example_beam_map(freq, nside, FWHM_major=1.1, FWHM_minor=1.1)
 Generate sky map using Global Sky Model.
 
 ```python
-def GDSM_sky_model(freq, nside)
+def GDSM_sky_model(*, freq, nside)
 ```
 
 ## Examples
@@ -526,13 +526,13 @@ plt.show()
 ### Example 3: Custom Beam and Sky Models
 
 ```python
-def custom_beam(freq, nside):
+def custom_beam(*, freq, nside, fwhm0=70):
     """Custom frequency-dependent beam"""
     # Beam size scales with frequency
-    fwhm = 70 / freq  # degrees, typical radio telescope scaling
-    return example_beam_map(freq, nside, FWHM_major=fwhm, FWHM_minor=fwhm*0.8)
+    fwhm = fwhm0 / freq  # degrees, typical radio telescope scaling
+    return example_beam_map(freq=freq, nside=nside, FWHM_major=fwhm, FWHM_minor=fwhm*0.8)
 
-def point_source_sky(freq, nside):
+def point_source_sky(*, freq, nside):
     """Sky with a single point source"""
     npix = hp.nside2npix(nside)
     sky = np.zeros(npix)

--- a/examples.ipynb
+++ b/examples.ipynb
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "8faa75a1",
    "metadata": {},
    "outputs": [
@@ -87,6 +87,9 @@
     "    beam_func=example_beam_map, # Return HEALPix beam array of shape (hp.nside2npix(nside))\n",
     "    sky_func=GDSM_sky_model     # Return HEALPix sky map of shape (hp.nside2npix(nside))\n",
     ")\n",
+    "\n",
+    "# Note: beam_func and sky_func require keyword-only arguments, two of which must be freq and nside:\n",
+    "# beam_func(*, freq, nside, ...) and sky_func(*, freq, nside)\n",
     "\n",
     "# Generate a simple scanning pattern\n",
     "time_list, azimuth_list = example_scan()\n",
@@ -251,7 +254,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "bdd54a03",
    "metadata": {},
    "outputs": [
@@ -303,20 +306,19 @@
     }
    ],
    "source": [
-    "def custom_beam(freq, nside):\n",
+    "def custom_beam(*, freq, nside, fwhm0=70):\n",
     "    \"\"\"Custom frequency-dependent beam\"\"\"\n",
     "    # Beam size scales with frequency\n",
-    "    fwhm = 100 / freq  # degrees, typical radio telescope scaling\n",
-    "    return example_beam_map(freq, nside, FWHM_major=fwhm, FWHM_minor=fwhm * 0.8)\n",
+    "    fwhm = fwhm0 / freq  # degrees, typical radio telescope scaling\n",
+    "    return example_beam_map(freq=freq, nside=nside, FWHM_major=fwhm, FWHM_minor=fwhm * 0.8)\n",
     "\n",
     "\n",
-    "def point_source_sky(freq, nside):\n",
+    "def point_source_sky(*, freq, nside, ra=180.0, dec=-30):\n",
     "    \"\"\"Sky with a single point source\"\"\"\n",
     "    npix = hp.nside2npix(nside)\n",
     "    sky = np.zeros(npix)\n",
     "\n",
     "    # Add point source at specific coordinates\n",
-    "    ra, dec = 180.0, -30.0  # degrees\n",
     "    theta = np.pi / 2 - np.radians(dec)\n",
     "    phi = np.radians(ra)\n",
     "\n",
@@ -364,7 +366,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "a16a6693",
    "metadata": {},
    "outputs": [
@@ -389,7 +391,7 @@
     }
    ],
    "source": [
-    "asym_beam = example_beam_map(900, FWHM_major=25, FWHM_minor=5, nside=64)\n",
+    "asym_beam = example_beam_map(freq=900, nside=64, FWHM_major=25, FWHM_minor=5)\n",
     "# Visualize the beam map\n",
     "plt.figure()\n",
     "hp.mollview(asym_beam, rot=(0, 90), title=\"Asymmetric Beam Map\")\n",

--- a/limTOD/simulator.py
+++ b/limTOD/simulator.py
@@ -300,14 +300,14 @@ def generate_TOD_sky(
     return np.array(tod)
 
 
-def GDSM_sky_model(freq, nside):
+def GDSM_sky_model(*, freq, nside):
     gsm = GlobalSkyModel()
     skymap = gsm.generate(freq)
     skymap = hp.ud_grade(skymap, nside_out=nside)
     return skymap
 
 
-def example_beam_map(freq, nside, FWHM_major=1.1, FWHM_minor=1.1):
+def example_beam_map(*, freq, nside, FWHM_major=1.1, FWHM_minor=1.1):
     """
     Generate an example Gaussian beam map.
     This toy model is achromatic.
@@ -413,8 +413,8 @@ class TODsim:
         )
 
         def single_freq_sky_TOD(freq):
-            beam_map = self.beam_func(freq, self.nside)
-            sky_map = self.sky_func(freq, self.nside)
+            beam_map = self.beam_func(freq=freq, nside=self.nside)
+            sky_map = self.sky_func(freq=freq, nside=self.nside)
 
             tod = generate_TOD_sky(
                 beam_map,


### PR DESCRIPTION
This PR redefine the signature of `beam_func` and `sky_func` to improve flexibility when defining these functions. It must now be defined as keyword-only inputs, two of which must be `freq` and `nside`.

Examples and README have been updated accordingly.